### PR TITLE
chore(build): Add -wl to build script to allow windows/linux multiplatform and add little tweaks

### DIFF
--- a/modules/ClientTxtWatcher.js
+++ b/modules/ClientTxtWatcher.js
@@ -35,6 +35,13 @@ function start() {
     inv = new InventoryGetter();
 
     tail.on("line", (line) => {
+      if (process.platform === 'linux') {
+        // Remove carriage return
+        // NOTE: PoE run on wine, the client.txt file has Windows carriage return
+        //       This cause an error when trying to execute the regexp on the line
+        line = JSON.stringify(line).replace(/(\\r\\n|\\n|\\r)/, '');
+        line = JSON.parse(line);
+      }
       if(line.toLowerCase().endsWith(`] @to ${settings.activeProfile.characterName.toLowerCase()}: end`)) {
         logger.info("Detected map end signal, processing last map run");
         RunParser.process();

--- a/package.json
+++ b/package.json
@@ -20,6 +20,13 @@
       "installerIcon": "./res/img/icons/win/ExileDiary.ico",
       "uninstallerIcon": "./res/img/icons/win/ExileDiary.ico",
       "installerHeaderIcon": "./res/img/icons/win/ExileDiary.ico"
+    },
+    "linux": {
+      "target": "deb",
+      "executableName": "Exile-Diary",
+      "icon": "./res/img/icons/png",
+      "category": "Utility",
+      "maintainer": "briansd9"
     }
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   "scripts": {
     "start": "electron .",
     "postinstall": "install-app-deps",
-    "pack": "electron-builder --dir",
-    "dist": "electron-builder"
+    "pack": "electron-builder -wl --dir",
+    "dist": "electron-builder -wl"
   },
   "keywords": [
     "util",


### PR DESCRIPTION
`-wl` means `windows` and `linux`.

This will now build a `.deb` of the software that will run and can be installed on linux OS.

You can also add `m` to the parameters to do the same for MacOS users

The releases would be the same as today but with the new `.deb` file and the new `latest-linux.yml` file

PS : [Here](https://www.electron.build/multi-platform-build) is the link to the multi-platform-build documentation of Electron-Builder